### PR TITLE
docs: clarify secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A lightweight library to query a hierarchy of configuration sources
 
 ```java
 Configuration config = Configuration.of(
-    secretsManager("my-secret-name", "eu-west-1"), // { "username": "user" }
-    properties("/etc/my-app-config.properties"),   // { "username": "anotherUser", "password": "secret" }
+    secretsManager("my-secret-name", "eu-west-1"), // { "username": "user", "password": "secret" }
+    properties("/etc/my-app-config.properties"),   // { "username": "anotherUser" }
 );
 
 Optional<String> username = config.get("username"); // Optional[user]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ This can be configured with:
 
  * `.secretsManager(String secretName, String region)` - uses default AWS client to query Secrets Manager.
  * `.secretsManager(String secretName, String region, AWSSecretsManager client)` - uses provided client to query Secrets Manager. Use this if you want to provide custom client behaviour e.g. using a specific set of credentials or instance-role.
+ 
+Secrets are only requested from AWS the first time they're accessed. Subsequent
+requests using the same configuration will use a cached response.
 
 **NOTE**: This configuration source only supports key-value pairs as a return type - plaintext secrets will be ignored.
 


### PR DESCRIPTION
I've updated the README to mention how requests are made to AWS as it may affect the user's AWS costs depending on how they use it. It will also make them aware that responses are cached so if they make any changes to a Secret, they'll need to restart the process or create a new configuration.

I didn't mention these issues explicitly in order to keep it brief.